### PR TITLE
Fix seed generation: provider failover for block timestamp lookups

### DIFF
--- a/webapp/scripts/generate-bet-seed.mjs
+++ b/webapp/scripts/generate-bet-seed.mjs
@@ -130,6 +130,22 @@ async function getBetCreatedLogs(fromBlock, toBlock, deadline) {
   return { logs, scannedTo: toBlock }
 }
 
+// Some free providers prune old block history ("pruned history unavailable"),
+// so header lookups need the same provider failover as everything else
+async function fetchBlockTimestamp(clientIndex, blockNumber) {
+  for (let attempt = 0; attempt < clients.length; attempt++) {
+    const client = clients[(clientIndex + attempt) % clients.length]
+    try {
+      const block = await client.getBlock({ blockNumber })
+      return Number(block.timestamp)
+    } catch {
+      // Try the next provider
+    }
+  }
+  console.warn(`No provider could serve block ${blockNumber}; timestamp 0`)
+  return 0
+}
+
 async function fetchDescription(clientIndex, txHash, betAddress) {
   for (let attempt = 0; attempt < clients.length; attempt++) {
     const client = clients[(clientIndex + attempt) % clients.length]
@@ -180,9 +196,7 @@ async function main() {
   const blockNumbers = [...new Set(logs.map((log) => log.blockNumber))]
   const timestamps = new Map()
   await mapInBatches(blockNumbers, 10, async (blockNumber, i) => {
-    const client = clients[i % clients.length]
-    const block = await client.getBlock({ blockNumber })
-    timestamps.set(blockNumber, Number(block.timestamp))
+    timestamps.set(blockNumber, await fetchBlockTimestamp(i, blockNumber))
   })
 
   const known = new Map(existing.bets.map((bet) => [bet.address, bet]))


### PR DESCRIPTION
The production seed scan completed (found all 122 bets) but then aborted at the timestamp step: `getBlock` was pinned to one provider per lookup and publicnode returned "pruned history unavailable" for old Base blocks, which threw away the entire scan and shipped an empty seed.

Timestamp lookups now fail over across all providers like the log and receipt fetches do, and fall back to `0` instead of aborting the whole seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExgoP9XPc7YyV4gmahWe9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExgoP9XPc7YyV4gmahWe9L)_