### PR TITLE
Fix bet detail drawer rendering off-screen

### DIFF
--- a/webapp/src/components/bet-detail-dialog.tsx
+++ b/webapp/src/components/bet-detail-dialog.tsx
@@ -437,7 +437,7 @@ export function BetDetailDialog({
         if (!isOpen) handleReset()
       }}
     >
-      <DrawerContent className="fixed relative bottom-0 left-0 right-0 mx-auto flex max-h-[90dvh] max-w-3xl flex-col pb-[env(safe-area-inset-bottom)]">
+      <DrawerContent className="fixed bottom-0 left-0 right-0 mx-auto flex max-h-[90dvh] max-w-3xl flex-col pb-[env(safe-area-inset-bottom)]">
         {/* Accept Success Overlay */}
         {showAcceptSuccess && (
           <div className="bg-background/95 absolute inset-0 z-30 flex flex-col items-center justify-center rounded-t-[10px] px-6 py-12">


### PR DESCRIPTION
Clicking a bet dimmed the screen with no visible sheet. The `DrawerContent` class list contained both `relative` and `fixed`; after the Tailwind class sort placed `relative` last, tailwind-merge dropped `fixed` and the drawer rendered in normal document flow below the viewport.

Removing the stray `relative` restores the fixed bottom-sheet. Reproduced and verified locally with Playwright against production data (drawer previously at y=2077 on a 900px viewport; now y=431, visible and anchored). Swept the rest of the app for other conflicting position-class pairs — none found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExgoP9XPc7YyV4gmahWe9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExgoP9XPc7YyV4gmahWe9L)_