### PR TITLE
Distinguish expired bets from cancelled; add Reclaim Funds action

### DIFF
--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -56,4 +56,10 @@ export type Bet = {
   winner: BetUser | null
   /** The taker, once they have accepted the bet */
   acceptedBy: BetUser | null
+  /**
+   * True when the bet lapsed (accept or judging deadline passed) but nobody
+   * has called cancel() yet - the stakes are still held by the bet contract.
+   * Such bets display as CANCELLED but funds are reclaimable.
+   */
+  expired: boolean
 }

--- a/webapp/src/components/bet-detail-dialog.tsx
+++ b/webapp/src/components/bet-detail-dialog.tsx
@@ -137,15 +137,23 @@ function BetHistory({ bet, onClose }: BetHistoryProps) {
           />
         )}
 
-        {/* Funds Returned - Show if cancelled */}
-        {bet.status === BetStatus.CANCELLED && (
-          <TimelineEvent
-            icon="💸"
-            title="Funds Returned"
-            description={`Funds returned to ${getDisplayName(bet.maker)}`}
-            link={contractLink}
-          />
-        )}
+        {/* Funds - Show if cancelled/expired */}
+        {bet.status === BetStatus.CANCELLED &&
+          (bet.expired ? (
+            <TimelineEvent
+              icon="💸"
+              title="Funds Reclaimable"
+              description="The stakes are still held by the bet contract and can be reclaimed"
+              link={contractLink}
+            />
+          ) : (
+            <TimelineEvent
+              icon="💸"
+              title="Funds Returned"
+              description={`Funds returned to ${getDisplayName(bet.maker)}`}
+              link={contractLink}
+            />
+          ))}
       </div>
 
       {/* Hide Details Link */}
@@ -206,8 +214,52 @@ function ActionCard({
     )
   }
 
-  // State 4: Cancelled
+  // State 4: Cancelled or expired
   if (bet.status === BetStatus.CANCELLED) {
+    // Expired: the deadline passed but the stakes are still in the contract
+    // until someone calls cancel() to reclaim them
+    if (bet.expired) {
+      const isParticipant = isMaker || isTaker || isJudge
+      return (
+        <div className="space-y-3 rounded-xl border bg-white px-4 py-3">
+          <div className="flex items-center justify-center gap-3">
+            <span className="text-2xl">⌛</span>
+            <span className="text-wb-brown text-center text-sm">
+              {bet.acceptedBy
+                ? 'The judging deadline passed without a winner being picked'
+                : 'The bet expired without being accepted'}
+              . The stake{bet.acceptedBy ? 's are' : ' is'} still held by the
+              bet contract.
+            </span>
+          </div>
+          {isParticipant ? (
+            <>
+              <Button
+                onClick={onCancelBet}
+                className="bg-wb-coral hover:bg-wb-coral/80 w-full text-white"
+                disabled={isPending}
+              >
+                {isCancelling ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : null}
+                {isCancelling ? 'Reclaiming...' : 'Reclaim Funds'}
+              </Button>
+              <p className="text-wb-taupe text-center text-xs">
+                Returns {bet.amount} USDC to {getDisplayName(bet.maker)}
+                {bet.acceptedBy
+                  ? ` and ${bet.amount} USDC to ${getDisplayName(bet.acceptedBy)}`
+                  : ''}
+              </p>
+            </>
+          ) : (
+            <p className="text-wb-taupe text-center text-xs">
+              Connect as a participant to reclaim the funds
+            </p>
+          )}
+        </div>
+      )
+    }
+
     return (
       <div className="rounded-xl border bg-white px-4 py-3">
         <div className="flex items-center justify-center gap-3">

--- a/webapp/src/lib/bets-server.ts
+++ b/webapp/src/lib/bets-server.ts
@@ -177,15 +177,16 @@ async function discoverNewBets(
 // Bet state - read live from the bet contracts via multicall
 // =============================================================================
 
-// IBet.Status enum indices; EXPIRED (5) renders as CANCELLED
+// IBet.Status enum indices 0-4; index 5 (EXPIRED) is handled separately
+// because expired bets still hold the stakes until someone calls cancel()
 const STATUS_BY_INDEX: BetStatus[] = [
   BetStatus.PENDING,
   BetStatus.ACTIVE,
   BetStatus.JUDGING,
   BetStatus.RESOLVED,
   BetStatus.CANCELLED,
-  BetStatus.CANCELLED,
 ]
+const EXPIRED_INDEX = 5
 
 const JUDGING_WINDOW_SECONDS = 30 * 24 * 60 * 60
 
@@ -200,28 +201,37 @@ type ChainBet = {
   makerStake: string
   status: BetStatus
   accepted: boolean
+  expired: boolean
   createdAt: number // unix seconds
   acceptBy: number
   endsBy: number
   judgeDeadline: number
 }
 
-// Normalize status across contract versions (v1's bet() may not time-derive)
+// Normalize status across contract versions (v1's bet() may not time-derive).
+// `expired` means the bet lapsed but cancel() hasn't been called - the stakes
+// are still held by the contract; a stored CANCELLED means they were refunded.
 function deriveStatus(
-  rawStatus: BetStatus,
+  statusIndex: number,
   acceptBy: number,
   endsBy: number,
   judgeDeadline: number
-): BetStatus {
+): { status: BetStatus; expired: boolean } {
   const now = Math.floor(Date.now() / 1000)
+  if (statusIndex === EXPIRED_INDEX) {
+    return { status: BetStatus.CANCELLED, expired: true }
+  }
+  const rawStatus = STATUS_BY_INDEX[statusIndex] ?? BetStatus.PENDING
   if (rawStatus === BetStatus.PENDING && now > acceptBy) {
-    return BetStatus.CANCELLED
+    return { status: BetStatus.CANCELLED, expired: true }
   }
   if (rawStatus === BetStatus.ACTIVE || rawStatus === BetStatus.JUDGING) {
-    if (now > judgeDeadline) return BetStatus.CANCELLED
-    if (now > endsBy) return BetStatus.JUDGING
+    if (now > judgeDeadline) {
+      return { status: BetStatus.CANCELLED, expired: true }
+    }
+    if (now > endsBy) return { status: BetStatus.JUDGING, expired: false }
   }
-  return rawStatus
+  return { status: rawStatus, expired: false }
 }
 
 async function loadChainBets(): Promise<ChainBet[]> {
@@ -282,8 +292,12 @@ async function loadChainBets(): Promise<ChainBet[]> {
     const acceptBy = Number(state.acceptBy)
     const endsBy = Number(state.endsBy)
     const judgeDeadline = endsBy + JUDGING_WINDOW_SECONDS
-    const rawStatus = STATUS_BY_INDEX[state.status] ?? BetStatus.PENDING
-    const status = deriveStatus(rawStatus, acceptBy, endsBy, judgeDeadline)
+    const { status, expired } = deriveStatus(
+      state.status,
+      acceptBy,
+      endsBy,
+      judgeDeadline
+    )
     const accepted =
       state.status === 1 || // ACTIVE
       state.status === 2 || // JUDGING
@@ -300,6 +314,7 @@ async function loadChainBets(): Promise<ChainBet[]> {
       makerStake: state.makerStake.toString(),
       status,
       accepted,
+      expired,
       createdAt: bet.createdAt,
       acceptBy,
       endsBy,
@@ -419,6 +434,7 @@ export async function getBets(): Promise<Bet[]> {
         judgeDeadline: toMs(bet.judgeDeadline),
         winner: bet.winner ? getUser(bet.winner) : null,
         acceptedBy: bet.accepted ? taker : null,
+        expired: bet.expired,
       }
     })
     .sort((a, b) => b.createdAt - a.createdAt)


### PR DESCRIPTION
Expired bets (accept or judging deadline passed, but `cancel()` never called) displayed as "The bet was cancelled and funds were returned" — incorrect, since the stakes are still held by the bet contract until someone calls `cancel()`.

- `/api/bets` now surfaces an `expired` flag: the contract's derived EXPIRED status (or the equivalent time-derivation for v1 bets) means funds are still locked; a stored CANCELLED means refunds already happened
- Expired bets show accurate copy ("expired without being accepted" / "judging deadline passed" + "the stake is still held by the bet contract") and a **Reclaim Funds** button for participants, which calls `cancel()` — per the contract, anyone may cancel an expired bet and refunds always go to the bettors
- The bet history timeline shows "Funds Reclaimable" instead of "Funds Returned" for expired bets

Verified locally with Playwright: expired bet drawer renders the new copy and reclaim prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExgoP9XPc7YyV4gmahWe9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExgoP9XPc7YyV4gmahWe9L)_